### PR TITLE
Updated watch filter to include subdirectories.

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,10 +143,15 @@ if (process.argv.length === 2) {
   if (watch) {
     var watch = require("watch");
     watch.watchTree(paths[0], {
+      ignoreDotFiles: true,
       filter: function(filename) {
-        for(var i=0; i<program.extensions.length; i++) {
-          if (filename.endsWith("." + program.extensions[i])) {
-            return true;
+        if (fs.statSync(filename).isDirectory()) {
+          return true;
+        } else {
+          for(var i=0; i<program.extensions.length; i++) {
+            if (filename.endsWith("." + program.extensions[i])) {
+              return true;
+            }
           }
         }
         return false;


### PR DESCRIPTION
The existing watch filter is including any file or directory which does not end with the specified extension. I've updated the filter to include all directories.
