### PR TITLE
Regex corrected for cross platform support

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function traverseDir(path, result, done) {
       }
       try {
         if (separator) {
-          var regex = new RegExp(pathModule.sep,'g');
+          var regex = new RegExp("\\" + pathModule.sep,'g');
           result[filename.replace(regex,separator)] = parser.parse(content, filename);
         } else {
           result[filename] = parser.parse(content, filename);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docstojson",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Generate code docs as a reusable json object",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Regex corrected for windows where path separator is \ which causes Invalid Regex error.